### PR TITLE
Add info rule for processing undefined instances

### DIFF
--- a/rules/base.json
+++ b/rules/base.json
@@ -87,7 +87,9 @@
             "description": {
                 "allow-types": ["string"]
             },
-            "default": {},
+            "default": {
+                "for-undefined": true
+            },
             "examples": {
                 "allow-types": ["array"]
             }
@@ -190,7 +192,8 @@
             },
             "required": {
                 "allow-types": ["boolean", "array"],
-                "for-types": ["object"]
+                "for-types": ["object"],
+                "for-undefined": true
             },
             "dependencies": {
                 "allow-types": ["object"],

--- a/rules/schema.json
+++ b/rules/schema.json
@@ -38,6 +38,11 @@
                     "description": "treat the value for this keyword as containing as-schema values",
                     "type": "boolean",
                     "default": false
+                },
+                "for-undefined": {
+                    "description": "whether this keyword should still be processed if the instance is undefined",
+                    "type": "boolean",
+                    "default": "false"
                 }
             },
             "additionalProperties": false

--- a/rules/standard/draft-04.json
+++ b/rules/standard/draft-04.json
@@ -31,7 +31,8 @@
                 "allow-types": ["object"]
             },
             "required": {
-                "allow-types": ["array"]
+                "allow-types": ["array"],
+                "for-undefined": false
             }
         }
     }

--- a/rules/standard/draft-06.json
+++ b/rules/standard/draft-06.json
@@ -22,7 +22,8 @@
                 "allow-types": ["number", "integer"]
             },
             "required": {
-                "allow-types": ["array"]
+                "allow-types": ["array"],
+                "for-undefined": false
             }
         }
     }


### PR DESCRIPTION
## What
 * Add info rule to determine whether a keyword should be processed even if the instance being validated is undefined.

## Why
 * Because some keywords apply to undefined instances (e.g. draft-03 boolean required), but most do not.